### PR TITLE
Make project file type extensions configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@ msbuild.exe for node.js
 
 **_It has been changed to allow the simple configurability of project name types._**
 
+__Configuring project extensions.__
+
+Create a file called msbprojectextensions.json in your project root, structured like the following:
+
+``` json
+{
+    "slnextn": "mycustomslnextention",
+    "projextn": "mycustomprojextn"
+}
+```
+
+This will configure the solution and project extensions usable by this package.  Defaults are .sln and .proj
+
+
+**_Below is the original readme._**
+
 Clean, Build, Package, Publish using publish profiles and params.
 
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 msbuild.exe for node.js
 
+**_This is a fork of [JHaker's nodejs-msbuild package](https://github.com/jhaker/nodejs-msbuild)_**
+
+**_It has been changed to allow the simple configurability of project name types._**
+
 Clean, Build, Package, Publish using publish profiles and params.
 
 

--- a/msbuild-config.json
+++ b/msbuild-config.json
@@ -1,4 +1,0 @@
-{
-  "solutionextn": "sln",
-  "projectextn": "proj"
-}

--- a/msbuild-config.json
+++ b/msbuild-config.json
@@ -1,0 +1,4 @@
+{
+  "solutionextn": "sln",
+  "projectextn": "proj"
+}

--- a/msbuild.js
+++ b/msbuild.js
@@ -6,6 +6,9 @@
  https://github.com/jhaker/nodejs-msbuild
 
 */
+
+var msbcfg = require("./msbuild-config.json");
+
 if (!String.prototype.endsWith) {
   String.prototype.endsWith = function(searchString, position) {
       var subjectString = this.toString();
@@ -264,7 +267,7 @@ msbuild.prototype.validateSourcePath = function(){
 }
 
 msbuild.prototype.validateSourcePathIsSolution = function(){
-	if(this.sourcePath.endsWith('sln')){
+	if(this.sourcePath.endsWith(msbcfg.solutionextn)){
 		return true;
 	}
 	else{
@@ -274,7 +277,7 @@ msbuild.prototype.validateSourcePathIsSolution = function(){
 }
 
 msbuild.prototype.validateSourcePathIsProject = function(){
-	if(this.sourcePath.endsWith('proj')){
+	if(this.sourcePath.endsWith(msbcfg.projectextn)){
 		return true;
 	}
 	else{
@@ -298,7 +301,7 @@ msbuild.prototype.build = function(){
 	} 
 	
 	if(!this.validateSourcePathIsSolution()){
-		this.abort('aborting...bad source path. package requires file type sln.');
+		this.abort('aborting...bad source path. package requires file type ' + msbcfg.solutionextn + '.');
 		return;
 	} 
 	
@@ -322,7 +325,7 @@ msbuild.prototype.package = function(){
 	} 
 	
 	if(!this.validateSourcePathIsProject()){
-		this.abort('aborting...bad source path. package requires file type proj.');
+		this.abort('aborting...bad source path. package requires file type ' + msbcfg.projectextn + '.');
 		return;
 	} 
 
@@ -344,7 +347,7 @@ msbuild.prototype.publish = function(){
 	} 
 	
 	if(!this.validateSourcePathIsProject()){
-		this.abort('aborting...bad source path. package requires file type proj.');
+		this.abort('aborting...bad source path. package requires file type ' + msbcfg.projectextn + '.');
 		return;
 	} 
 	

--- a/msbuild.js
+++ b/msbuild.js
@@ -7,8 +7,6 @@
 
 */
 
-var msbcfg = require("./msbuild-config.json");
-
 if (!String.prototype.endsWith) {
   String.prototype.endsWith = function(searchString, position) {
       var subjectString = this.toString();
@@ -25,7 +23,8 @@ var events = require('events'),
 	colors = require('colors'),
 	fs = require('fs'),
 	  path = require('path'),
-	  spawn = require('child_process').spawn;
+	  spawn = require('child_process').spawn,
+	approot = require('app-root-path');
 
 	
 var default_os = require('os').platform();
@@ -107,6 +106,25 @@ var msbuild = function(){
 		'12.0': '12.0',
         '14.0': '14.0'
 	};
+	this.projectextensions = {
+		solutionextn: "sln",
+		projectextn: "proj"
+	};
+
+	if (fs.exists(approot.toString() + 'msbprojectextensions.json')){
+
+		var obj = require('./msbprojectextensions.json');
+
+		if (obj.hasOwnProperty('slnextn')) {
+
+			this.projectextensions.solutionextn = obj.slnextn;
+		}
+
+		if (obj.hasOwnProperty('projextn')) {
+
+			this.projectextensions.projectextn = obj.projextn;
+		}
+	}
 };
 
 msbuild.prototype = new defaultValues();
@@ -267,7 +285,7 @@ msbuild.prototype.validateSourcePath = function(){
 }
 
 msbuild.prototype.validateSourcePathIsSolution = function(){
-	if(this.sourcePath.endsWith(msbcfg.solutionextn)){
+	if(this.sourcePath.endsWith(this.projectextensions.solutionextn)){
 		return true;
 	}
 	else{
@@ -277,7 +295,7 @@ msbuild.prototype.validateSourcePathIsSolution = function(){
 }
 
 msbuild.prototype.validateSourcePathIsProject = function(){
-	if(this.sourcePath.endsWith(msbcfg.projectextn)){
+	if(this.sourcePath.endsWith(this.projectextensions.projectextn)){
 		return true;
 	}
 	else{
@@ -301,7 +319,7 @@ msbuild.prototype.build = function(){
 	} 
 	
 	if(!this.validateSourcePathIsSolution()){
-		this.abort('aborting...bad source path. package requires file type ' + msbcfg.solutionextn + '.');
+		this.abort('aborting...bad source path. package requires file type ' + this.projectextensions.solutionextn + '.');
 		return;
 	} 
 	
@@ -325,7 +343,7 @@ msbuild.prototype.package = function(){
 	} 
 	
 	if(!this.validateSourcePathIsProject()){
-		this.abort('aborting...bad source path. package requires file type ' + msbcfg.projectextn + '.');
+		this.abort('aborting...bad source path. package requires file type ' + this.projectextensions.projectextn + '.');
 		return;
 	} 
 
@@ -347,7 +365,7 @@ msbuild.prototype.publish = function(){
 	} 
 	
 	if(!this.validateSourcePathIsProject()){
-		this.abort('aborting...bad source path. package requires file type ' + msbcfg.projectextn + '.');
+		this.abort('aborting...bad source path. package requires file type ' + this.projectextensions.projectextn + '.');
 		return;
 	} 
 	

--- a/msbuild.js
+++ b/msbuild.js
@@ -106,14 +106,17 @@ var msbuild = function(){
 		'12.0': '12.0',
         '14.0': '14.0'
 	};
+
 	this.projectextensions = {
 		solutionextn: "sln",
 		projectextn: "proj"
 	};
 
-	if (fs.exists(approot.toString() + 'msbprojectextensions.json')){
+	var theprojextnconfigpath = path.normalize(approot.toString() + path.sep + 'msbprojectextensions.json');
 
-		var obj = require('./msbprojectextensions.json');
+	if (fs.existsSync(theprojextnconfigpath)){
+
+		var obj = require(theprojextnconfigpath);
 
 		if (obj.hasOwnProperty('slnextn')) {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msbuild-configurable",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "msbuild helpers for .net apps",
   "main": "msbuild.js",
   "repository": {
@@ -11,16 +11,16 @@
     "url": "https://github.com/jhaker/nodejs-msbuild/issues"
   },
   "dependencies": {
-		"async":"*",
-		"colors":"*",
-		"events":"*"
+    "async": "*",
+    "colors": "*",
+    "events": "*"
   },
   "devDependencies": {
-		"async":"*",
-		"colors":"*",
-		"events":"*",
-        "should": ">= 2.0.x",
-        "mocha": "~1.14.0"
+    "async": "*",
+    "colors": "*",
+    "events": "*",
+    "should": ">= 2.0.x",
+    "mocha": "~1.14.0"
   },
   "optionalDependencies": {},
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "msbuild",
+  "name": "msbuild-configurable",
   "version": "0.3.1",
   "description": "msbuild helpers for .net apps",
   "main": "msbuild.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jhaker/nodejs-msbuild.git"
+    "url": "https://github.com/RedmonkeyDF/nodejs-msbuildconfigurable.git"
   },
   "bugs": {
     "url": "https://github.com/jhaker/nodejs-msbuild/issues"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "msbuild-configurable",
+  "name": "@redmonkeydf/msbuild-configurable",
   "version": "0.4.0",
   "description": "msbuild helpers for .net apps",
   "main": "msbuild.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redmonkeydf/msbuild-configurable",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "msbuild helpers for .net apps",
   "main": "msbuild.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/jhaker/nodejs-msbuild/issues"
   },
   "dependencies": {
+    "app-root-path": "^1.2.1",
     "async": "*",
     "colors": "*",
     "events": "*"


### PR DESCRIPTION
MSBuild is open source, and a lot of projects are starting to use it with extensions other than .sln and .proj

This solves that problem and makes these extensions configurable via file in the application root, and defaults to the built in type if this file is not found.