### PR TITLE
Find the correct msbuild.exe for VS2017 installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msbuild",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "msbuild wrapper",
   "main": "msbuild.js",
   "scripts": {


### PR DESCRIPTION
This should fix fully issue #16
(https://github.com/jhaker/nodejs-msbuild/issues/16)