### PR TITLE
Add support for MSBuild version 16.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msbuild",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -49,5 +49,5 @@
     "type": "git",
     "url": "git+https://github.com/jhaker/nodejs-msbuild.git"
   },
-  "version": "1.0.3"
+  "version": "1.0.4"
 }


### PR DESCRIPTION
Add support for the newest version of MSBuild, which was released with Visual Studio 2019.