### PR TITLE
BUGFIX #20

### DIFF
--- a/msbuild.js
+++ b/msbuild.js
@@ -154,6 +154,12 @@ msbuild.prototype.getMSBuildPath = function(os,processor,version){
 			return process.env.vsInstallDir;
 	}
 	
+	// For the msbuild 14.0 version
+	if (version === "14.0") {
+		msbuildDir = getvsInstallDir(programFilesDir + '\\' + 'Microsoft Visual Studio\\2017\\');
+		exeDir = msbuildDir + 'MSBuild\\'+version+'\\bin\\msbuild.exe';	
+	}
+	
 	// For the msbuild 15.0 version, use the appropriate VS2017 directories
 	if (version === "15.0") {
 		msbuildDir = getvsInstallDir(programFilesDir + '\\' + 'Microsoft Visual Studio\\2017\\');


### PR DESCRIPTION
```c#
var msbuild_srv = new _msbuild();
msbuild_srv.sourcePath = path.join(cwd, '/DemoSolution.Service/DemoSolution.Service.csproj');
msbuild_srv.overrideParams.push('/p:DeployOnBuild=true');
msbuild_srv.config('version','14.0')

msbuild_srv.overrideParams.push('/p:PublishProfile=' + path.join(cwd, 'con_svc.pubxml'));
msbuild_srv.configuration = 'release';
msbuild_srv.publish();
```